### PR TITLE
Postgresql GPG keys path changed

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,7 +35,7 @@ postgresql_conf: "{{ base_postgresql_conf | combine(extra_postgresql_conf) }}"
 postgresql_yum_repository_url: "http://yum.postgresql.org"
 postgresql_pgdg_repository_url: "https://download.postgresql.org/pub/repos/yum/"
 postgresql_yum_repository_baseurl: "{{ postgresql_yum_repository_url }}/{{ postgresql_version }}/{{ ansible_os_family | lower }}/rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}"
-postgresql_yum_repository_gpgkey: "{{ postgresql_pgdg_repository_url }}/RPM-GPG-KEY-PGDG-{{ postgresql_version_terse }}"
+postgresql_yum_repository_gpgkey: "{{ postgresql_pgdg_repository_url }}/keys/RPM-GPG-KEY-PGDG-{{ postgresql_version_terse }}"
 
 # APT repo URL
 postgresql_apt_repository_url: "https://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg {{ postgresql_version }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,7 +35,7 @@ postgresql_conf: "{{ base_postgresql_conf | combine(extra_postgresql_conf) }}"
 postgresql_yum_repository_url: "http://yum.postgresql.org"
 postgresql_pgdg_repository_url: "https://download.postgresql.org/pub/repos/yum/"
 postgresql_yum_repository_baseurl: "{{ postgresql_yum_repository_url }}/{{ postgresql_version }}/{{ ansible_os_family | lower }}/rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}"
-postgresql_yum_repository_gpgkey: "{{ postgresql_pgdg_repository_url }}/keys/RPM-GPG-KEY-PGDG-{{ postgresql_version_terse }}"
+postgresql_yum_repository_gpgkey: "{{ postgresql_pgdg_repository_url }}/keys/PGDG-RPM-GPG-KEY-RHEL"
 
 # APT repo URL
 postgresql_apt_repository_url: "https://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg {{ postgresql_version }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,7 +35,7 @@ postgresql_conf: "{{ base_postgresql_conf | combine(extra_postgresql_conf) }}"
 postgresql_yum_repository_url: "http://yum.postgresql.org"
 postgresql_pgdg_repository_url: "https://download.postgresql.org/pub/repos/yum/"
 postgresql_yum_repository_baseurl: "{{ postgresql_yum_repository_url }}/{{ postgresql_version }}/{{ ansible_os_family | lower }}/rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}"
-postgresql_yum_repository_gpgkey: "{{ postgresql_pgdg_repository_url }}/keys/PGDG-RPM-GPG-KEY-RHEL"
+postgresql_yum_repository_gpgkey: "{{ postgresql_pgdg_repository_url }}/keys/PGDG-RPM-GPG-KEY-RHEL{{ ansible_distribution_major_version }}"
 
 # APT repo URL
 postgresql_apt_repository_url: "https://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg {{ postgresql_version }}"


### PR DESCRIPTION
Issue :
```

Transaction Summary
============================================================================================================================================================
Install  4 Packages (+5 Dependent packages)

Total size: 17 M
Total download size: 7.0 M
Installed size: 81 M
Is this ok [y/d/N]: y
Downloading packages:
(1/2): python3-3.6.8-19.el7_9.x86_64.rpm                                                                                             |  70 kB  00:00:01
(2/2): python3-libs-3.6.8-19.el7_9.x86_64.rpm                                                                                        | 6.9 MB  00:00:01
------------------------------------------------------------------------------------------------------------------------------------------------------------
Total                                                                                                                       3.5 MB/s | 7.0 MB  00:00:01
warning: /var/cache/yum/x86_64/7/postgresql/packages/postgresql14-libs-14.10-1PGDG.rhel7.x86_64.rpm: Header V4 RSA/SHA1 Signature, key ID 73e3b907: NOKEY
Retrieving key from https://download.postgresql.org/pub/repos/yum//RPM-GPG-KEY-PGDG-14


GPG key retrieval failed: [Errno 14] HTTPS Error 404 - Not Found
Uploading Enabled Repositories Report
```


Cause: Keys were moved to `[keys](https://download.postgresql.org/pub/repos/yum/keys/RPM-GPG-KEY-PGDG-14)` folder